### PR TITLE
Fix: resolve late binding loop in get_column

### DIFF
--- a/e6data_python_connector/dialect.py
+++ b/e6data_python_connector/dialect.py
@@ -316,7 +316,9 @@ class E6dataDialect(default.DefaultDialect):
         for column in columns:
             row = dict()
             row["name"] = column.get('fieldName')
-            row["type"] = lambda: column.get('fieldType')
+            raw_type = str(column.get('fieldType')).lower()
+            mapped_type = _type_map.get(raw_type, types.String)
+            row["type"] = lambda t=mapped_type: t
             rows.append(row)
         return rows
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>BUG: <code inline="">get_columns()</code> incorrectly reports all column types due to a late-binding closure bug</h1><h2>Summary</h2><p>The <code inline="">get_columns()</code> implementation in the e6data SQLAlchemy dialect incorrectly reports the data type of every reflected column. Instead of returning each column's actual SQL type, all columns are assigned the data type of the <strong>last column</strong> in the table.</p><p>This issue breaks SQLAlchemy schema reflection and affects downstream tools such as Great Expectations that rely on accurate column metadata.</p><h2>Root Cause</h2><p>The bug is caused by a classic Python <strong>late-binding closure</strong> issue in the implementation of <code inline="">get_columns()</code>.</p><p>Current implementation:</p><pre><code class="language-python">for column in columns:
    row = dict()
    row["name"] = column.get("fieldName")

    # BUG: lambda captures the variable reference, not its current value
    row["type"] = lambda: column.get("fieldType")

    rows.append(row)

return rows
</code></pre><p>In Python, closures capture <strong>variables by reference</strong>, not by value.</p><p>The lambda does <strong>not</strong> store the value of <code inline="">column</code> during each iteration. Instead, every lambda retains a reference to the same <code inline="">column</code> variable. After the loop completes, that variable refers to the <strong>last element</strong> in the <code inline="">columns</code> list.</p><p>When SQLAlchemy later evaluates the lambda to determine the column type, every lambda resolves to:</p><pre><code class="language-python">last_column.get("fieldType")
</code></pre><p>As a result, every reflected column is assigned the type of the last column in the schema.</p><h2>Example</h2><p>Actual table schema:</p>
Column | Actual Type
-- | --
id | INTEGER
name | VARCHAR
salary | DOUBLE
created_at | TIMESTAMP

<p>Expected output from <code inline="">get_columns()</code>:</p><pre><code class="language-text">id          -&gt; INTEGER
name        -&gt; VARCHAR
salary      -&gt; DOUBLE
created_at  -&gt; TIMESTAMP
</code></pre><p>Actual output:</p><pre><code class="language-text">id          -&gt; TIMESTAMP
name        -&gt; TIMESTAMP
salary      -&gt; TIMESTAMP
created_at  -&gt; TIMESTAMP
</code></pre><p>Since <code inline="">created_at</code> is the last column, every reflected column incorrectly reports <code inline="">TIMESTAMP</code>.</p><h2>Additional Issue</h2><p>The implementation also ignores the <code inline="">_type_map</code> defined earlier in the dialect.</p><p>Instead of converting e6data-specific string type names into corresponding SQLAlchemy <code inline="">types.*</code> objects, the raw <code inline="">fieldType</code> value is returned directly.</p><p>This results in two independent problems:</p><ol><li><p><strong>Incorrect closure behavior</strong>, causing every column to resolve to the last column's type.</p></li><li><p><strong>No type mapping</strong>, preventing e6data type strings from being translated into the appropriate SQLAlchemy type objects.</p></li></ol><h2>Impact</h2><p>This bug affects all consumers of SQLAlchemy's reflection API, including:</p><ul><li><p>SQLAlchemy Inspector</p></li><li><p>Great Expectations</p></li><li><p>Alembic</p></li><li><p>ORM schema inspection</p></li><li><p>Any tooling that relies on reflected metadata</p></li></ul><p>Since every column appears to have the same type, type-aware validation and schema introspection become unreliable. In Great Expectations, this can cause type-based expectations (such as numeric, string, date, or timestamp validations) to fail or behave incorrectly.</p><h2>Expected Behavior</h2><p><code inline="">get_columns()</code> should:</p><ul><li><p>Return the correct SQLAlchemy type for each individual column.</p></li><li><p>Resolve each column's type independently.</p></li><li><p>Use the existing <code inline="">_type_map</code> to convert e6data type names into SQLAlchemy <code inline="">types.*</code> objects before returning the reflected metadata.</p></li></ul></body></html><!--EndFragment-->
</body>
</html>